### PR TITLE
Add valset id

### DIFF
--- a/contracts/Turnstone.vy
+++ b/contracts/Turnstone.vy
@@ -37,6 +37,7 @@ event LogicCallEvent:
     message_id: uint256
 
 last_checkpoint: public(bytes32)
+last_valset_id: public(uint256)
 message_id_used: public(HashMap[uint256, bool])
 
 # turnstone_id: unique identifier for turnstone instance
@@ -122,6 +123,7 @@ def update_valset(new_valset: Valset, consensus: Consensus):
     # check if enough validators signed new validator set (new checkpoint)
     self.check_validator_signatures(consensus, new_checkpoint)
     self.last_checkpoint = new_checkpoint
+    self.last_valset_id = new_valset.valset_id
     log ValsetUpdated(new_checkpoint, new_valset.valset_id)
 
 # This makes calls to contracts that execute arbitrary logic

--- a/tests/test_update_valset.py
+++ b/tests/test_update_valset.py
@@ -16,6 +16,7 @@ def test_update_valset_success(TurnstoneContract, validators, powers, accounts):
         {"from": accounts[0]}
     )
     assert TurnstoneContract.last_checkpoint() == hash.hex()
+    assert TurnstoneContract.last_valset_id == new_valset_id
 
 def test_update_valset_invalid_valset_id_revert(TurnstoneContract, validators, powers, accounts):
     func_sig = function_signature("checkpoint(address[],uint256[],uint256,bytes32)")


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/189

# Background

I'd like to get latest snapshot that's available on the turnstone-evm by its ID.

# Testing completed

- [ ] _a list of actions that you've performed to ensure that this PR works as intended_
- [ ] _99% of the times you should have an item: "wrote tests"_
